### PR TITLE
fix: publish only triiger in publish-gd-ui branches pull_request merged

### DIFF
--- a/.github/workflows/publish-gd-ui.yml
+++ b/.github/workflows/publish-gd-ui.yml
@@ -9,6 +9,8 @@ on:
   
 jobs:
   publish:
+    # 新增startsWith，用于修复非publish-gd-ui分支的pull_request合并到main分支，也会触发该工作流进行发布npm包
+    if: startsWith(github.head_ref, "publish-gd-ui")
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: "publish npm"


### PR DESCRIPTION
only trigger publish to npm when pubish-gd-ui branch pull_request merged to main.